### PR TITLE
Fix deprecated syntax

### DIFF
--- a/ps_disable_auto_formatting.php
+++ b/ps_disable_auto_formatting.php
@@ -309,4 +309,4 @@ function version_too_old() {
 
 } // class end
 
-$ps_disable_auto_formatting =& new ps_disable_auto_formatting();
+$ps_disable_auto_formatting = new ps_disable_auto_formatting();


### PR DESCRIPTION
I'm not sure whether this repository is official, but this commit is just a small fixes for following error.  The message was added from PHP 5.3.

> Assigning the return value of new by reference is deprecated

You don't use assigned value in other places so it seems to be harmless to stop using reference.

FYI: this issue was reported on official support threads.

https://wordpress.org/support/topic/error-line-310-assigning-the-return-value-of-new-by-reference-is-deprecated
https://wordpress.org/support/topic/erros-in-wp-debug-mode
